### PR TITLE
Feature gate multi-threaded sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "rdst"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "arbitrary-chunks",
  "block-pseudorand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ keywords = ["radix","sort","rayon","parallel","multithreaded"]
 documentation = "https://docs.rs/rdst/"
 
 [features]
-default = ["default-implementations"]
+default = ["multi-threaded"]
 bench = ["criterion", "block-pseudorand"]
 tuning = ["criterion", "block-pseudorand", "jemallocator"]
-default-implementations = []
+multi-threaded = ["rayon"]
 work_profiles = []
 
 [dependencies]
-rayon = "1.5.1"
+rayon = { version = "1.5.1", optional = true }
 arbitrary-chunks = "0.4.0"
 try-mutex = "0.4.0"
 partition = "0.1.2"
@@ -28,6 +28,7 @@ block-pseudorand = { version = "0.1.1", optional = true }
 jemallocator = { version = "0.3.2", optional = true }
 
 [dev-dependencies]
+rayon = "1.5.1"
 voracious_radix_sort = { version = "1.1.0", features = ["voracious_multithread"] }
 num_cpus = "1.13.0"
 criterion = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rdst"
 description = "A flexible parallel unstable radix sort that supports sorting by any arbitrarily defined sequence of bytes."
-version = "0.19.2"
+version = "0.20.0"
 authors = ["Nathan Essex <nathan@essex.id.au>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"

--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ my_vec
     .sort();
 ```
 
+NOTE: If you are ONLY using the single-threaded variant of this radix sort, you can disable the default `"multi-threaded"` feature on the `rdst` dependency to remove large sub-dependencies like Rayon.
+
+```
+[dependencies.rdst]
+version = "x.y.z"
+default-features = false
+```
+
+With the `"multi-threaded"` feature disabled, even the default `my_data.radix_sort_unstable()` will use a single-threaded tuner.
+
 ## Custom Tuners
 
 Tuners are things which you can implement to control which sorting algorithms are used. There are many radix sorting algorithms implemented as part of this crate, and they all have their pros and cons. If you have a very specific use-case it may be worth your time to tune the sort yourself.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,6 @@
 //! Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.
 
 mod radix_key;
-#[cfg(feature = "default-implementations")]
 mod radix_key_impl;
 mod radix_sort_builder;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,16 @@
 //!     .sort();
 //! ```
 //!
+//! NOTE: If you are ONLY using the single-threaded variant of this radix sort, you can disable the default `"multi-threaded"` feature on the `rdst` dependency to remove large sub-dependencies like Rayon.
+//!
+//! ```toml
+//! [dependencies.rdst]
+//! version = "x.y.z"
+//! default-features = false
+//! ```
+//!
+//! With the `"multi-threaded"` feature disabled, even the default `my_data.radix_sort_unstable()` will use a single-threaded tuner.
+//!
 //! ## Custom Tuners
 //!
 //! Tuners are things which you can implement to control which sorting algorithms are used. There are many radix sorting algorithms implemented as part of this crate, and they all have their pros and cons. If you have a very specific use-case it may be worth your time to tune the sort yourself.

--- a/src/radix_sort_builder.rs
+++ b/src/radix_sort_builder.rs
@@ -1,6 +1,15 @@
 use crate::sorter::Sorter;
 use crate::tuner::Tuner;
-use crate::tuners::{LowMemoryTuner, SingleThreadedTuner, StandardTuner};
+#[cfg(feature = "multi-threaded")]
+use {
+    crate::tuners::{
+        LowMemoryTuner,
+        StandardTuner,
+    }
+};
+use crate::tuners::{
+    SingleThreadedTuner,
+};
 use crate::RadixKey;
 
 pub struct RadixSortBuilder<'a, T> {
@@ -18,11 +27,10 @@ where
         // This is an invariant of RadixKey that must be upheld.
         assert_ne!(T::LEVELS, 0, "RadixKey must have at least 1 level");
 
-        let (tuner, multi_threaded): (&(dyn Tuner + Send + Sync), bool) = if cfg!(feature = "multi-threaded") {
-            (&StandardTuner, true)
-        } else {
-            (&SingleThreadedTuner, false)
-        };
+        #[cfg(feature = "multi-threaded")]
+        let (tuner, multi_threaded) = (&StandardTuner, true);
+        #[cfg(not(feature = "multi-threaded"))]
+        let (tuner, multi_threaded) = (&SingleThreadedTuner, false);
 
         Self {
             data,
@@ -48,7 +56,6 @@ where
     ///     .with_single_threaded_tuner()
     ///     .sort();
     /// ```
-    #[cfg(feature = "multi-threaded")]
     pub fn with_parallel(mut self, parallel: bool) -> Self {
         self.multi_threaded = parallel;
 

--- a/src/radix_sort_builder.rs
+++ b/src/radix_sort_builder.rs
@@ -18,10 +18,16 @@ where
         // This is an invariant of RadixKey that must be upheld.
         assert_ne!(T::LEVELS, 0, "RadixKey must have at least 1 level");
 
+        let (tuner, multi_threaded): (&(dyn Tuner + Send + Sync), bool) = if cfg!(feature = "multi-threaded") {
+            (&StandardTuner, true)
+        } else {
+            (&SingleThreadedTuner, false)
+        };
+
         Self {
             data,
-            multi_threaded: true,
-            tuner: &StandardTuner,
+            multi_threaded,
+            tuner,
         }
     }
 
@@ -42,6 +48,7 @@ where
     ///     .with_single_threaded_tuner()
     ///     .sort();
     /// ```
+    #[cfg(feature = "multi-threaded")]
     pub fn with_parallel(mut self, parallel: bool) -> Self {
         self.multi_threaded = parallel;
 
@@ -62,6 +69,7 @@ where
     ///     .with_low_mem_tuner()
     ///     .sort();
     /// ```
+    #[cfg(feature = "multi-threaded")]
     pub fn with_low_mem_tuner(mut self) -> Self {
         self.tuner = &LowMemoryTuner;
 

--- a/src/sorter.rs
+++ b/src/sorter.rs
@@ -2,7 +2,9 @@ use crate::tuner::{Algorithm, Tuner, TuningParams};
 use crate::utils::*;
 use crate::RadixKey;
 use arbitrary_chunks::ArbitraryChunks;
+#[cfg(feature = "multi-threaded")]
 use rayon::current_num_threads;
+#[cfg(feature = "multi-threaded")]
 use rayon::prelude::*;
 use std::cmp::max;
 
@@ -26,11 +28,13 @@ impl<'a> Sorter<'a> {
         bucket: &mut [T],
         counts: &[usize; 256],
         tile_counts: Option<Vec<[usize; 256]>>,
+        #[allow(unused)]
         tile_size: usize,
         algorithm: Algorithm,
     ) where
         T: RadixKey + Copy + Sized + Send + Sync,
     {
+        #[allow(unused)]
         if let Some(tile_counts) = tile_counts {
             match algorithm {
                 #[cfg(feature = "multi-threaded")]
@@ -62,6 +66,7 @@ impl<'a> Sorter<'a> {
                 Algorithm::Lsb => self.lsb_sort_adapter(false, bucket, counts, 0, level),
                 Algorithm::Ska => self.ska_sort_adapter(bucket, counts, level),
                 Algorithm::Comparative => self.comparative_sort(bucket, level),
+                #[cfg(feature = "multi-threaded")]
                 e => panic!("Bad algorithm: {:?} for len: {}", e, bucket.len()),
             }
         }
@@ -92,7 +97,11 @@ impl<'a> Sorter<'a> {
             parent_len,
         };
 
-        let mut tile_counts = if self.multi_threaded && chunk.len() >= 260_000 {
+        let mut tile_counts = if
+            cfg!(feature = "multi-threaded") &&
+            self.multi_threaded &&
+            chunk.len() >= 260_000
+        {
             Some(get_tile_counts(chunk, tile_size, level))
         } else {
             None
@@ -121,6 +130,7 @@ impl<'a> Sorter<'a> {
         // Ensure tile_counts is always set when it is required
         if tile_counts.is_none() {
             tile_counts = match algorithm {
+                #[cfg(feature = "multi-threaded")]
                 Algorithm::MtOop | Algorithm::Recombinating | Algorithm::Regions => {
                     Some(vec![counts.clone()])
                 }
@@ -139,13 +149,19 @@ impl<'a> Sorter<'a> {
     where
         T: RadixKey + Sized + Send + Copy + Sync,
     {
+        #[cfg(feature = "multi-threaded")]
         let threads = current_num_threads();
+
+        #[cfg(not(feature = "multi-threaded"))]
+        let threads = 1;
+
         let level = T::LEVELS - 1;
 
         self.handle_chunk(bucket, level, None, threads);
     }
 
     #[inline]
+    #[cfg(feature = "multi-threaded")]
     pub fn multi_threaded_director<T>(&self, bucket: &mut [T], counts: &[usize; 256], level: usize)
     where
         T: RadixKey + Send + Copy + Sync,
@@ -177,7 +193,8 @@ impl<'a> Sorter<'a> {
     where
         T: RadixKey + Send + Sync + Copy,
     {
-        if self.multi_threaded {
+        if cfg!(feature = "multi-threaded") && self.multi_threaded {
+            #[cfg(feature = "multi-threaded")]
             self.multi_threaded_director(bucket, counts, level);
         } else {
             self.single_threaded_director(bucket, counts, level);

--- a/src/sorter.rs
+++ b/src/sorter.rs
@@ -33,7 +33,9 @@ impl<'a> Sorter<'a> {
     {
         if let Some(tile_counts) = tile_counts {
             match algorithm {
+                #[cfg(feature = "multi-threaded")]
                 Algorithm::Scanning => self.scanning_sort_adapter(bucket, counts, level),
+                #[cfg(feature = "multi-threaded")]
                 Algorithm::Recombinating => {
                     self.recombinating_sort_adapter(bucket, counts, &tile_counts, tile_size, level)
                 }
@@ -41,16 +43,20 @@ impl<'a> Sorter<'a> {
                 Algorithm::Lsb => self.lsb_sort_adapter(false, bucket, counts, 0, level),
                 Algorithm::Ska => self.ska_sort_adapter(bucket, counts, level),
                 Algorithm::Comparative => self.comparative_sort(bucket, level),
+                #[cfg(feature = "multi-threaded")]
                 Algorithm::Regions => {
                     self.regions_sort_adapter(bucket, counts, &tile_counts, tile_size, level)
                 }
+                #[cfg(feature = "multi-threaded")]
                 Algorithm::MtOop => {
                     self.mt_oop_sort_adapter(bucket, level, counts, &tile_counts, tile_size)
                 }
+                #[cfg(feature = "multi-threaded")]
                 Algorithm::MtLsb => self.mt_lsb_sort_adapter(bucket, 0, level, tile_size),
             }
         } else {
             match algorithm {
+                #[cfg(feature = "multi-threaded")]
                 Algorithm::Scanning => self.scanning_sort_adapter(bucket, counts, level),
                 Algorithm::LrLsb => self.lsb_sort_adapter(true, bucket, counts, 0, level),
                 Algorithm::Lsb => self.lsb_sort_adapter(false, bucket, counts, 0, level),

--- a/src/sorts/mod.rs
+++ b/src/sorts/mod.rs
@@ -1,8 +1,25 @@
-pub mod comparative_sort;
-pub mod lsb_sort;
-pub mod mt_lsb_sort;
-pub mod out_of_place_sort;
-pub mod recombinating_sort;
-pub mod regions_sort;
-pub mod scanning_sort;
-pub mod ska_sort;
+mod comparative_sort;
+mod lsb_sort;
+#[cfg(feature = "multi-threaded")]
+mod mt_lsb_sort;
+mod out_of_place_sort;
+#[cfg(feature = "multi-threaded")]
+mod recombinating_sort;
+#[cfg(feature = "multi-threaded")]
+mod regions_sort;
+#[cfg(feature = "multi-threaded")]
+mod scanning_sort;
+mod ska_sort;
+
+pub use comparative_sort::*;
+pub use lsb_sort::*;
+#[cfg(feature = "multi-threaded")]
+pub use mt_lsb_sort::*;
+pub use out_of_place_sort::*;
+#[cfg(feature = "multi-threaded")]
+pub use recombinating_sort::*;
+#[cfg(feature = "multi-threaded")]
+pub use regions_sort::*;
+#[cfg(feature = "multi-threaded")]
+pub use scanning_sort::*;
+pub use ska_sort::*;

--- a/src/tuner.rs
+++ b/src/tuner.rs
@@ -8,8 +8,8 @@ pub struct TuningParams {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[cfg(feature = "multi-threaded")]
 pub enum Algorithm {
-    #[allow(unused)]
     MtOop,
     MtLsb,
     Scanning,
@@ -18,6 +18,15 @@ pub enum Algorithm {
     LrLsb,
     Lsb,
     Regions,
+    Ska,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[cfg(not(feature = "multi-threaded"))]
+pub enum Algorithm {
+    Comparative,
+    LrLsb,
+    Lsb,
     Ska,
 }
 

--- a/src/tuners/mod.rs
+++ b/src/tuners/mod.rs
@@ -1,7 +1,11 @@
+#[cfg(feature = "multi-threaded")]
 mod low_memory_tuner;
+#[cfg(feature = "multi-threaded")]
 mod standard_tuner;
 mod single_threaded_tuner;
 
+#[cfg(feature = "multi-threaded")]
 pub use low_memory_tuner::LowMemoryTuner;
+#[cfg(feature = "multi-threaded")]
 pub use standard_tuner::StandardTuner;
 pub use single_threaded_tuner::SingleThreadedTuner;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,6 @@
-#[cfg(any(test, feature = "bench", feature = "tuning"))]
+#[cfg(all(feature = "multi-threaded", any(test, feature = "bench", feature = "tuning")))]
 pub mod bench_utils;
-#[cfg(any(test, feature = "bench", feature = "tuning"))]
+#[cfg(all(feature = "multi-threaded", any(test, feature = "bench", feature = "tuning")))]
 pub mod test_utils;
 
 mod sort_utils;


### PR DESCRIPTION
## WHAT

Feature gate multi-threaded sorting, behind a default feature.

This allows you to remove all multi-threading related logic by using:
`default-features = false`

## WHY

Multi-threaded sorting requires importing `rayon`. If you are only using this library in a single-threaded configuration, this introduces a lot of unnecessary overhead and bloat.

Fixes: https://github.com/Nessex/rdst/issues/2